### PR TITLE
fixed registration success undefined error

### DIFF
--- a/src/resources/views/users.php
+++ b/src/resources/views/users.php
@@ -6,6 +6,10 @@ $error_message = null;
 
 $csrfToken = Csrf::generateToken();
 
+if (!isset($_SESSION["registration_success"])) {
+    $_SESSION["registration_success"] = null;
+}
+
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
Previously, the $_SESSION["registration_success"] variable was left undefined. This fixes that so we're not having unnecessary errors thrown.